### PR TITLE
Adding registry mirror parameter on source

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Tracks and builds [Docker](https://docker.io) images.
 * `insecure_registries`: *Optional.* An array of CIDRs or `host:port` addresses
   to whitelist for insecure access (either `http` or unverified `https`).
 
+* `registry_mirror`: *Optional.* A URL pointing to a docker registry mirror service.
+
 Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 
 ## Behavior

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -55,6 +55,10 @@ start_docker() {
     server_args="${server_args} --insecure-registry ${registry}"
   done
 
+  if [[ -n $2 ]]; then
+    server_args="${server_args} --registry-mirror=$2"
+  fi
+
   docker daemon ${server_args} >/tmp/docker.log 2>&1 &
   echo $! > /tmp/docker.pid
 

--- a/assets/in
+++ b/assets/in
@@ -24,7 +24,9 @@ cat > $payload <&0
 
 insecure_registries=$(jq -r '.source.insecure_registries // [] | join(" ")' < $payload)
 
-start_docker "$insecure_registries"
+registry_mirror=$(jq -r '.source.registry_mirror // ""' < $payload)
+
+start_docker "$insecure_registries" "$registry_mirror"
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -26,7 +26,9 @@ cd $source
 
 insecure_registries=$(jq -r '.source.insecure_registries // [] | join(" ")' < $payload)
 
-start_docker "$insecure_registries"
+registry_mirror=$(jq -r '.source.registry_mirror // ""' < $payload)
+
+start_docker "$insecure_registries" "$registry_mirror"
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -28,6 +28,12 @@ func main() {
 
 	registryHost, repo := parseRepository(request.Source.Repository)
 
+	if len(request.Source.RegistryMirror) > 0 {
+		registryMirrorUrl, err := url.Parse(request.Source.RegistryMirror)
+		fatalIf("failed to parse registry mirror URL", err)
+		registryHost = registryMirrorUrl.Host
+	}
+
 	tag := request.Source.Tag
 	if tag == "" {
 		tag = "latest"

--- a/cmd/check/models.go
+++ b/cmd/check/models.go
@@ -7,6 +7,7 @@ type Source struct {
 	Password           string   `json:"password"`
 	Email              string   `json:"email"`
 	InsecureRegistries []string `json:"insecure_registries"`
+	RegistryMirror     string   `json:"registry_mirror"`
 }
 
 type Version struct {


### PR DESCRIPTION
Adding a registry_mirror property on the docker-image source to allow using registry mirroring.
